### PR TITLE
feat: add /api/credits fallback for accounts without portal_url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ATM",
-  "version": "1.2.3",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ATM",
-      "version": "1.2.3",
+      "version": "1.3.8",
       "dependencies": {
         "@tauri-apps/api": "^2.9.0",
         "@vueuse/core": "^14.0.0",

--- a/src/components/credit/CreditUsageModal.vue
+++ b/src/components/credit/CreditUsageModal.vue
@@ -77,6 +77,12 @@ const fetchData = async () => {
 
     statsData.value = result.stats_data
     chartData.value = result.chart_data
+
+    // 优先使用 /api/credits 返回的实时余额（用于新版本账户）
+    if (result.credits_data && result.credits_data.usage_units_remaining !== undefined) {
+      remainingCredits.value = Math.round(result.credits_data.usage_units_remaining)
+      console.log('Using real-time credits:', result.credits_data)
+    }
   } catch (e) {
     error.value = e.toString()
     console.error('Failed to fetch credit data:', e)


### PR DESCRIPTION
- Add get_credits_with_app_session function to fetch real-time credits
- Modify batch_check_account_status to use /api/credits when portal_url is unavailable
- Update CreditUsageModal to prioritize credits_data for balance display
- Support new account types that don't have portal_url