### PR TITLE
feat(openai): 为 OAuth 账号增加反代开关并限制 Codex 仅使用启用账号

### DIFF
--- a/src-tauri/src/data/database/openai/migrations.rs
+++ b/src-tauri/src/data/database/openai/migrations.rs
@@ -40,6 +40,7 @@ pub async fn create_tables(
         CREATE TABLE IF NOT EXISTS openai_accounts (
             id VARCHAR(255) PRIMARY KEY,
             email TEXT NOT NULL,
+            reverse_proxy_enabled BOOLEAN NOT NULL DEFAULT TRUE,
             access_token TEXT NOT NULL,
             refresh_token TEXT,
             id_token TEXT,
@@ -257,6 +258,29 @@ pub async fn add_new_fields_if_not_exist(
             )
             .await?;
         println!("Added column rt_invalid_reason to openai_accounts");
+    }
+
+    let check_reverse_proxy_enabled = client
+        .query_one(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = 'openai_accounts'
+                AND column_name = 'reverse_proxy_enabled'
+            )",
+            &[],
+        )
+        .await?;
+
+    let reverse_proxy_enabled_exists: bool = check_reverse_proxy_enabled.get(0);
+    if !reverse_proxy_enabled_exists {
+        client
+            .execute(
+                "ALTER TABLE openai_accounts ADD COLUMN reverse_proxy_enabled BOOLEAN NOT NULL DEFAULT TRUE",
+                &[],
+            )
+            .await?;
+        println!("Added column reverse_proxy_enabled to openai_accounts");
     }
 
     // 添加 API 账号字段

--- a/src-tauri/src/data/storage/openai/mapper.rs
+++ b/src-tauri/src/data/storage/openai/mapper.rs
@@ -94,6 +94,7 @@ impl AccountDbMapper<Account> for OpenAIAccountMapper {
         Ok(Account {
             id: row.get(0),
             email: row.get(1),
+            reverse_proxy_enabled: row.try_get(37).unwrap_or(true),
             account_type,
             token,
             api_config,
@@ -122,7 +123,7 @@ impl AccountDbMapper<Account> for OpenAIAccountMapper {
          codex_7d_used_percent, codex_7d_reset_after_seconds, codex_7d_window_minutes, \
          codex_primary_over_secondary_percent, codex_usage_updated_at, \
          account_type, model_provider, model, model_reasoning_effort, wire_api, base_url, api_key, \
-         openai_auth_json, is_forbidden, rt_invalid, rt_invalid_reason"
+         openai_auth_json, is_forbidden, rt_invalid, rt_invalid_reason, reverse_proxy_enabled"
     }
 
     fn insert_sql() -> &'static str {
@@ -133,8 +134,8 @@ impl AccountDbMapper<Account> for OpenAIAccountMapper {
              version, deleted, tag, tag_color, codex_5h_used_percent, codex_5h_reset_after_seconds, codex_5h_window_minutes,
              codex_7d_used_percent, codex_7d_reset_after_seconds, codex_7d_window_minutes,
              codex_primary_over_secondary_percent, codex_usage_updated_at, account_type,
-             model_provider, model, model_reasoning_effort, wire_api, base_url, api_key, openai_auth_json, is_forbidden, rt_invalid, rt_invalid_reason)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37)
+             model_provider, model, model_reasoning_effort, wire_api, base_url, api_key, openai_auth_json, is_forbidden, rt_invalid, rt_invalid_reason, reverse_proxy_enabled)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38)
         ON CONFLICT (id) DO UPDATE SET
             email = EXCLUDED.email,
             access_token = EXCLUDED.access_token,
@@ -170,7 +171,8 @@ impl AccountDbMapper<Account> for OpenAIAccountMapper {
             openai_auth_json = EXCLUDED.openai_auth_json,
             is_forbidden = EXCLUDED.is_forbidden,
             rt_invalid = EXCLUDED.rt_invalid,
-            rt_invalid_reason = EXCLUDED.rt_invalid_reason
+            rt_invalid_reason = EXCLUDED.rt_invalid_reason,
+            reverse_proxy_enabled = EXCLUDED.reverse_proxy_enabled
         "#
     }
 
@@ -289,6 +291,7 @@ impl AccountDbMapper<Account> for OpenAIAccountMapper {
             Box::new(is_forbidden),
             Box::new(account.rt_invalid),
             Box::new(account.rt_invalid_reason.clone()),
+            Box::new(account.reverse_proxy_enabled),
         ]
     }
 }

--- a/src-tauri/src/platforms/openai/codex/models.rs
+++ b/src-tauri/src/platforms/openai/codex/models.rs
@@ -78,6 +78,10 @@ impl CodexPoolAccount {
     pub fn from_openai_account(
         account: &crate::platforms::openai::models::Account,
     ) -> Option<Self> {
+        if !account.reverse_proxy_enabled {
+            return None;
+        }
+
         let token = account.token.as_ref()?;
 
         // 跳过被禁用的账号
@@ -321,6 +325,38 @@ pub struct DailyStats {
     pub date: String,
     pub requests: u64,
     pub tokens: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CodexPoolAccount;
+    use crate::platforms::openai::models::{Account, TokenData};
+
+    fn sample_token() -> TokenData {
+        TokenData {
+            access_token: "access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            id_token: None,
+            expires_in: 3600,
+            expires_at: chrono::Utc::now().timestamp() + 3600,
+            token_type: Some("Bearer".to_string()),
+        }
+    }
+
+    #[test]
+    fn from_openai_account_skips_accounts_with_reverse_proxy_disabled() {
+        let mut account = Account::new_oauth(
+            "user@example.com".to_string(),
+            sample_token(),
+            Some("acct".to_string()),
+            None,
+            None,
+        );
+        account.reverse_proxy_enabled = false;
+
+        let pooled = CodexPoolAccount::from_openai_account(&account);
+        assert!(pooled.is_none());
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/platforms/openai/codex/pool.rs
+++ b/src-tauri/src/platforms/openai/codex/pool.rs
@@ -128,14 +128,13 @@ impl CodexPool {
     async fn select_single(&self, pool: &[CodexPoolAccount]) -> Option<CodexPoolAccount> {
         let selected_id = self.selected_account_id.read().await.clone();
 
-        let account = if let Some(id) = selected_id {
-            pool.iter()
-                .find(|a| a.id == id && a.is_available())
-                .cloned()
-        } else {
-            // 没有选中账号时，使用第一个可用账号
-            pool.iter().find(|a| a.is_available()).cloned()
-        };
+        let account = selected_id
+            .as_ref()
+            .and_then(|id| pool.iter().find(|a| a.id == *id && a.is_available()).cloned())
+            .or_else(|| {
+                // 选中账号不可用时，回退到第一个可用账号，避免服务被无声卡死。
+                pool.iter().find(|a| a.is_available()).cloned()
+            });
 
         if account.is_some() {
             // 增加请求计数
@@ -357,6 +356,55 @@ impl CodexPool {
 impl Default for CodexPool {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CodexPool, PoolStrategy};
+    use crate::platforms::openai::codex::models::CodexPoolAccount;
+
+    fn sample_pool_account(id: &str) -> CodexPoolAccount {
+        let now = chrono::Utc::now().timestamp();
+        CodexPoolAccount {
+            id: id.to_string(),
+            email: format!("{id}@example.com"),
+            access_token: "access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            id_token: None,
+            expires_at: now + 3600,
+            chatgpt_account_id: id.to_string(),
+            chatgpt_user_id: None,
+            organization_id: None,
+            is_active: true,
+            is_forbidden: false,
+            last_used: Some(now),
+            last_refresh: None,
+            cooldown_until: None,
+            unavailable_reason: None,
+            last_error_status: None,
+            daily_quota: None,
+            used_quota: 0,
+            total_tokens_used: 0,
+            codex_5h_used_percent: None,
+            codex_7d_used_percent: None,
+            plan_type: None,
+            subscription_expires_at: None,
+            tag: None,
+            tag_color: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn select_single_falls_back_to_first_available_account() {
+        let pool = CodexPool::new();
+        pool.add_account(sample_pool_account("primary")).await;
+        pool.add_account(sample_pool_account("fallback")).await;
+        pool.set_strategy(PoolStrategy::Single).await;
+        pool.set_selected_account_id("missing-in-pool".to_string()).await;
+
+        let selected = pool.next_account().await.unwrap();
+        assert_eq!(selected.id, "primary");
     }
 }
 

--- a/src-tauri/src/platforms/openai/models/account.rs
+++ b/src-tauri/src/platforms/openai/models/account.rs
@@ -2,6 +2,10 @@ use super::{QuotaData, TokenData};
 use crate::data::storage::common::SyncableAccount;
 use serde::{Deserialize, Serialize};
 
+fn default_reverse_proxy_enabled() -> bool {
+    true
+}
+
 /// 账号类型
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -44,6 +48,8 @@ pub struct ApiConfig {
 pub struct Account {
     pub id: String,
     pub email: String,
+    #[serde(default = "default_reverse_proxy_enabled")]
+    pub reverse_proxy_enabled: bool,
     /// 账号类型
     #[serde(default)]
     pub account_type: AccountType,
@@ -149,6 +155,7 @@ impl Account {
         Self {
             id,
             email,
+            reverse_proxy_enabled: true,
             account_type: AccountType::OAuth,
             token: Some(token),
             api_config: None,
@@ -176,6 +183,7 @@ impl Account {
         Self {
             id,
             email,
+            reverse_proxy_enabled: true,
             account_type: AccountType::API,
             token: None,
             api_config: Some(api_config),
@@ -250,5 +258,54 @@ impl Account {
     pub fn update_quota(&mut self, quota: QuotaData) {
         self.quota = Some(quota);
         self.updated_at = chrono::Utc::now().timestamp();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_token() -> TokenData {
+        TokenData {
+            access_token: "access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            id_token: None,
+            expires_in: 3600,
+            expires_at: chrono::Utc::now().timestamp() + 3600,
+            token_type: Some("Bearer".to_string()),
+        }
+    }
+
+    #[test]
+    fn reverse_proxy_defaults_to_true_for_legacy_account_json() {
+        let legacy = json!({
+            "id": "oauth-1",
+            "email": "user@example.com",
+            "account_type": "oauth",
+            "token": sample_token(),
+            "created_at": 1,
+            "last_used": 1,
+            "updated_at": 1,
+            "version": 0,
+            "deleted": false,
+            "rt_invalid": false
+        });
+
+        let account: Account = serde_json::from_value(legacy).unwrap();
+        assert!(account.reverse_proxy_enabled);
+    }
+
+    #[test]
+    fn new_oauth_account_enables_reverse_proxy_by_default() {
+        let account = Account::new_oauth(
+            "user@example.com".to_string(),
+            sample_token(),
+            Some("acct".to_string()),
+            None,
+            None,
+        );
+
+        assert!(account.reverse_proxy_enabled);
     }
 }

--- a/src/components/openai/AccountCard.vue
+++ b/src/components/openai/AccountCard.vue
@@ -104,6 +104,12 @@
             </svg>
             <span>{{ $t('accountCard.copyAccessToken') }}</span>
           </button>
+          <button v-if="hasThirdPartyCredentialTemplates" @click="handleMenuClick('copyThirdPartyCredentials', close)" class="dropdown-item">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+            </svg>
+            <span>{{ $t('platform.openai.thirdPartyCredentials.openMenu') }}</span>
+          </button>
           <button v-if="reverseProxyAction" @click="handleMenuClick('toggleReverseProxy', close)" class="dropdown-item">
             <svg v-if="reverseProxyAction === 'enable'" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
               <path d="M7 7h10a4 4 0 1 1 0 8H7a4 4 0 1 1 0-8zm0 2a2 2 0 0 0 0 4h10a2 2 0 0 0 0-4H7zm9 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/>
@@ -356,6 +362,7 @@ import { useI18n } from 'vue-i18n'
 import FloatingDropdown from '../common/FloatingDropdown.vue'
 import TagEditorModal from '../token/TagEditorModal.vue'
 import { getReverseProxyAction, toggleReverseProxyForAccount } from '@/utils/openaiReverseProxy'
+import { getAvailableOpenAIThirdPartyCredentialTemplates } from '@/utils/openaiThirdPartyCredentials'
 
 const { t: $t } = useI18n()
 
@@ -398,7 +405,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['refresh-quota', 'delete', 'select', 'switch', 'account-updated', 'edit'])
+const emit = defineEmits(['refresh-quota', 'delete', 'select', 'switch', 'account-updated', 'edit', 'copy-third-party-credentials'])
 
 const menuRef = ref(null)
 const showTagEditor = ref(false)
@@ -608,6 +615,10 @@ const reverseProxyActionLabel = computed(() => {
   return ''
 })
 
+const hasThirdPartyCredentialTemplates = computed(() => {
+  return getAvailableOpenAIThirdPartyCredentialTemplates(props.account).length > 0
+})
+
 const handleReverseProxyToggle = () => {
   const action = reverseProxyAction.value
   const updated = toggleReverseProxyForAccount(props.account)
@@ -676,6 +687,9 @@ const handleMenuClick = async (type, close) => {
       break
     case 'toggleReverseProxy':
       handleReverseProxyToggle()
+      break
+    case 'copyThirdPartyCredentials':
+      emit('copy-third-party-credentials', props.account)
       break
     case 'delete':
       emit('delete', props.account.id)

--- a/src/components/openai/AccountCard.vue
+++ b/src/components/openai/AccountCard.vue
@@ -104,6 +104,15 @@
             </svg>
             <span>{{ $t('accountCard.copyAccessToken') }}</span>
           </button>
+          <button v-if="reverseProxyAction" @click="handleMenuClick('toggleReverseProxy', close)" class="dropdown-item">
+            <svg v-if="reverseProxyAction === 'enable'" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M7 7h10a4 4 0 1 1 0 8H7a4 4 0 1 1 0-8zm0 2a2 2 0 0 0 0 4h10a2 2 0 0 0 0-4H7zm9 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/>
+            </svg>
+            <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M7 7h10a4 4 0 1 1 0 8H7a4 4 0 1 1 0-8zm0 2a2 2 0 0 0 0 4h10a2 2 0 0 0 0-4H7zm1 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/>
+            </svg>
+            <span>{{ reverseProxyActionLabel }}</span>
+          </button>
           <button v-if="isApiAccount && account.api_config?.key" @click="handleMenuClick('copyApiKey', close)" class="dropdown-item">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
               <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
@@ -346,6 +355,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import FloatingDropdown from '../common/FloatingDropdown.vue'
 import TagEditorModal from '../token/TagEditorModal.vue'
+import { getReverseProxyAction, toggleReverseProxyForAccount } from '@/utils/openaiReverseProxy'
 
 const { t: $t } = useI18n()
 
@@ -586,6 +596,31 @@ const handleTagClear = () => {
   window.$notify?.success($t('messages.tagCleared'))
 }
 
+const reverseProxyAction = computed(() => getReverseProxyAction(props.account))
+
+const reverseProxyActionLabel = computed(() => {
+  if (reverseProxyAction.value === 'disable') {
+    return $t('platform.openai.disableReverseProxy')
+  }
+  if (reverseProxyAction.value === 'enable') {
+    return $t('platform.openai.enableReverseProxy')
+  }
+  return ''
+})
+
+const handleReverseProxyToggle = () => {
+  const action = reverseProxyAction.value
+  const updated = toggleReverseProxyForAccount(props.account)
+  if (!updated) return
+
+  emit('account-updated', props.account)
+  window.$notify?.success(
+    action === 'disable'
+      ? $t('platform.openai.reverseProxyDisabledSuccess')
+      : $t('platform.openai.reverseProxyEnabledSuccess')
+  )
+}
+
 // 复制操作
 const copyEmail = async () => {
   try {
@@ -638,6 +673,9 @@ const handleMenuClick = async (type, close) => {
       break
     case 'copyBaseUrl':
       await copyBaseUrl()
+      break
+    case 'toggleReverseProxy':
+      handleReverseProxyToggle()
       break
     case 'delete':
       emit('delete', props.account.id)

--- a/src/components/openai/AccountTableRow.vue
+++ b/src/components/openai/AccountTableRow.vue
@@ -204,6 +204,12 @@
               </svg>
               <span>{{ $t('accountCard.copyAccessToken') }}</span>
             </button>
+            <button v-if="hasThirdPartyCredentialTemplates" @click="handleCopyMenuClick('copyThirdPartyCredentials', close)" class="dropdown-item">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
+              </svg>
+              <span>{{ $t('platform.openai.thirdPartyCredentials.openMenu') }}</span>
+            </button>
             <button v-if="reverseProxyAction" @click="handleCopyMenuClick('toggleReverseProxy', close)" class="dropdown-item">
               <svg v-if="reverseProxyAction === 'enable'" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M7 7h10a4 4 0 1 1 0 8H7a4 4 0 1 1 0-8zm0 2a2 2 0 0 0 0 4h10a2 2 0 0 0 0-4H7zm9 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/>
@@ -253,6 +259,7 @@ import { useI18n } from 'vue-i18n'
 import FloatingDropdown from '../common/FloatingDropdown.vue'
 import TagEditorModal from '../token/TagEditorModal.vue'
 import { getReverseProxyAction, toggleReverseProxyForAccount } from '@/utils/openaiReverseProxy'
+import { getAvailableOpenAIThirdPartyCredentialTemplates } from '@/utils/openaiThirdPartyCredentials'
 
 const { t: $t } = useI18n()
 
@@ -297,7 +304,7 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['refresh', 'refresh-quota', 'delete', 'select', 'switch', 'account-updated'])
+const emit = defineEmits(['refresh', 'refresh-quota', 'delete', 'select', 'switch', 'account-updated', 'copy-third-party-credentials'])
 
 // 复制菜单状态
 const copyMenuRef = ref(null)
@@ -383,6 +390,10 @@ const reverseProxyActionLabel = computed(() => {
   return ''
 })
 
+const hasThirdPartyCredentialTemplates = computed(() => {
+  return getAvailableOpenAIThirdPartyCredentialTemplates(props.account).length > 0
+})
+
 const handleReverseProxyToggle = () => {
   const action = reverseProxyAction.value
   const updated = toggleReverseProxyForAccount(props.account)
@@ -415,6 +426,9 @@ const handleCopyMenuClick = async (type, close) => {
       break
     case 'toggleReverseProxy':
       handleReverseProxyToggle()
+      break
+    case 'copyThirdPartyCredentials':
+      emit('copy-third-party-credentials', props.account)
       break
     case 'delete':
       emit('delete', props.account.id)

--- a/src/components/openai/AccountTableRow.vue
+++ b/src/components/openai/AccountTableRow.vue
@@ -204,6 +204,15 @@
               </svg>
               <span>{{ $t('accountCard.copyAccessToken') }}</span>
             </button>
+            <button v-if="reverseProxyAction" @click="handleCopyMenuClick('toggleReverseProxy', close)" class="dropdown-item">
+              <svg v-if="reverseProxyAction === 'enable'" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M7 7h10a4 4 0 1 1 0 8H7a4 4 0 1 1 0-8zm0 2a2 2 0 0 0 0 4h10a2 2 0 0 0 0-4H7zm9 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/>
+              </svg>
+              <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M7 7h10a4 4 0 1 1 0 8H7a4 4 0 1 1 0-8zm0 2a2 2 0 0 0 0 4h10a2 2 0 0 0 0-4H7zm1 1.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3z"/>
+              </svg>
+              <span>{{ reverseProxyActionLabel }}</span>
+            </button>
             <button v-if="isApiAccount && account.api_config?.key" @click="handleCopyMenuClick('copyApiKey', close)" class="dropdown-item">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/>
@@ -243,6 +252,7 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import FloatingDropdown from '../common/FloatingDropdown.vue'
 import TagEditorModal from '../token/TagEditorModal.vue'
+import { getReverseProxyAction, toggleReverseProxyForAccount } from '@/utils/openaiReverseProxy'
 
 const { t: $t } = useI18n()
 
@@ -361,6 +371,31 @@ const handleTagClear = () => {
   window.$notify?.success($t('messages.tagCleared'))
 }
 
+const reverseProxyAction = computed(() => getReverseProxyAction(props.account))
+
+const reverseProxyActionLabel = computed(() => {
+  if (reverseProxyAction.value === 'disable') {
+    return $t('platform.openai.disableReverseProxy')
+  }
+  if (reverseProxyAction.value === 'enable') {
+    return $t('platform.openai.enableReverseProxy')
+  }
+  return ''
+})
+
+const handleReverseProxyToggle = () => {
+  const action = reverseProxyAction.value
+  const updated = toggleReverseProxyForAccount(props.account)
+  if (!updated) return
+
+  emit('account-updated', props.account)
+  window.$notify?.success(
+    action === 'disable'
+      ? $t('platform.openai.reverseProxyDisabledSuccess')
+      : $t('platform.openai.reverseProxyEnabledSuccess')
+  )
+}
+
 // 复制菜单操作
 const handleCopyMenuClick = async (type, close) => {
   close?.()
@@ -377,6 +412,9 @@ const handleCopyMenuClick = async (type, close) => {
       break
     case 'copyBaseUrl':
       await copyBaseUrl()
+      break
+    case 'toggleReverseProxy':
+      handleReverseProxyToggle()
       break
     case 'delete':
       emit('delete', props.account.id)

--- a/src/components/openai/OpenAIThirdPartyCredentialModal.vue
+++ b/src/components/openai/OpenAIThirdPartyCredentialModal.vue
@@ -1,0 +1,131 @@
+<template>
+  <BaseModal
+    :visible="true"
+    :title="$t('platform.openai.thirdPartyCredentials.title')"
+    :show-close="true"
+    :close-on-overlay="true"
+    :close-on-esc="true"
+    :body-scroll="false"
+    modal-class="max-w-[720px]"
+    @close="emit('close')"
+  >
+    <div class="flex flex-col gap-4">
+      <div class="rounded-lg border border-border bg-muted/40 px-3 py-2.5">
+        <div class="text-xs text-text-muted">{{ $t('platform.openai.thirdPartyCredentials.account') }}</div>
+        <div class="mt-1 break-all text-sm font-medium text-text">{{ account?.email || '-' }}</div>
+      </div>
+
+      <div class="form-group mb-0">
+        <label class="label">{{ $t('platform.openai.thirdPartyCredentials.template') }}</label>
+        <select v-model="selectedTemplateId" class="input">
+          <option
+            v-for="template in availableTemplates"
+            :key="template.id"
+            :value="template.id"
+          >
+            {{ template.label }}
+          </option>
+        </select>
+        <p class="mt-1.5 text-xs text-text-muted">
+          {{ $t('platform.openai.thirdPartyCredentials.hint') }}
+        </p>
+      </div>
+
+      <div class="rounded-lg border border-border bg-muted/30 p-3">
+        <div class="mb-2 flex items-center justify-between gap-3">
+          <span class="text-xs font-medium text-text-secondary">{{ $t('platform.openai.thirdPartyCredentials.preview') }}</span>
+          <span class="text-[11px] uppercase text-text-muted">{{ selectedTemplateLabel }}</span>
+        </div>
+        <textarea
+          :value="previewContent"
+          readonly
+          class="input min-h-[320px] resize-none font-mono text-[12px] leading-5"
+        ></textarea>
+      </div>
+    </div>
+
+    <template #footer>
+      <button class="btn btn--secondary" @click="emit('close')">
+        {{ $t('common.cancel') }}
+      </button>
+      <button class="btn btn--primary" :disabled="!canCopy" @click="copyContent">
+        {{ $t('platform.openai.thirdPartyCredentials.copy') }}
+      </button>
+    </template>
+  </BaseModal>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import BaseModal from '@/components/common/BaseModal.vue'
+import {
+  buildOpenAIThirdPartyCredentialPreview,
+  getAvailableOpenAIThirdPartyCredentialTemplates
+} from '@/utils/openaiThirdPartyCredentials'
+
+const props = defineProps({
+  account: {
+    type: Object,
+    required: true
+  }
+})
+
+const emit = defineEmits(['close'])
+const { t: $t } = useI18n()
+
+const selectedTemplateId = ref('')
+
+const availableTemplates = computed(() => {
+  return getAvailableOpenAIThirdPartyCredentialTemplates(props.account)
+})
+
+watch(
+  availableTemplates,
+  (templates) => {
+    if (templates.some((template) => template.id === selectedTemplateId.value)) {
+      return
+    }
+    selectedTemplateId.value = templates[0]?.id || ''
+  },
+  { immediate: true }
+)
+
+const selectedTemplate = computed(() => {
+  return availableTemplates.value.find((template) => template.id === selectedTemplateId.value) || null
+})
+
+const selectedTemplateLabel = computed(() => {
+  return selectedTemplate.value?.label || '-'
+})
+
+const previewContent = computed(() => {
+  if (!selectedTemplate.value) {
+    return $t('platform.openai.thirdPartyCredentials.empty')
+  }
+
+  try {
+    return buildOpenAIThirdPartyCredentialPreview(props.account, selectedTemplate.value.id)
+  } catch (error) {
+    return error?.message || $t('platform.openai.thirdPartyCredentials.copyFailed')
+  }
+})
+
+const canCopy = computed(() => Boolean(selectedTemplate.value))
+
+const copyContent = async () => {
+  if (!selectedTemplate.value) return
+
+  try {
+    await navigator.clipboard.writeText(previewContent.value)
+    window.$notify?.success(
+      $t('platform.openai.thirdPartyCredentials.copySuccess', {
+        name: selectedTemplate.value.label
+      })
+    )
+    emit('close')
+  } catch {
+    window.$notify?.error($t('platform.openai.thirdPartyCredentials.copyFailed'))
+  }
+}
+</script>

--- a/src/components/platform/OpenAIAccountManager.vue
+++ b/src/components/platform/OpenAIAccountManager.vue
@@ -124,6 +124,7 @@
             @select="toggleAccountSelection"
             @account-updated="handleAccountUpdated"
             @edit="handleEdit"
+            @copy-third-party-credentials="openThirdPartyCredentialModal"
           />
         </div>
 
@@ -168,6 +169,7 @@
                 @delete="handleDelete"
                 @select="toggleAccountSelection"
                 @account-updated="handleAccountUpdated"
+                @copy-third-party-credentials="openThirdPartyCredentialModal"
               />
             </tbody>
           </table>
@@ -584,6 +586,12 @@
       @saved="handleEditSaved"
     />
 
+    <OpenAIThirdPartyCredentialModal
+      v-if="thirdPartyCredentialAccount"
+      :account="thirdPartyCredentialAccount"
+      @close="thirdPartyCredentialAccount = null"
+    />
+
     <CodexServerDialog v-if="showCodexDialog" @close="showCodexDialog = false" />
     <CodexRuntimeSettingsModal
       v-if="showCodexSettingsModal"
@@ -622,6 +630,7 @@ import AccountTableRow from '../openai/AccountTableRow.vue'
 import AddAccountDialog from '../openai/AddAccountDialog.vue'
 import OpenAIImportAccountsDialog from '../openai/OpenAIImportAccountsDialog.vue'
 import EditApiAccountDialog from '../openai/EditApiAccountDialog.vue'
+import OpenAIThirdPartyCredentialModal from '../openai/OpenAIThirdPartyCredentialModal.vue'
 import CodexServerDialog from '../openai/CodexServerDialog.vue'
 import CodexRuntimeSettingsModal from '../openai/CodexRuntimeSettingsModal.vue'
 import SyncQueueModal from '../common/SyncQueueModal.vue'
@@ -655,6 +664,7 @@ const showImportDialog = ref(false)
 const showCodexDialog = ref(false)
 const showCodexSettingsModal = ref(false)
 const editingAccount = ref(null)
+const thirdPartyCredentialAccount = ref(null)
 const isLoading = ref(false)
 const refreshingIds = ref(new Set())
 const deletingIds = ref(new Set())
@@ -1152,6 +1162,10 @@ const handleEditSaved = async (updatedAccount) => {
   }
   markItemUpsertById(updatedAccount.id)
   window.$notify?.success($t('platform.openai.messages.updateSuccess'))
+}
+
+const openThirdPartyCredentialModal = (account) => {
+  thirdPartyCredentialAccount.value = account
 }
 
 const handleDelete = async (accountId) => {

--- a/src/components/platform/OpenAIAccountManager.vue
+++ b/src/components/platform/OpenAIAccountManager.vue
@@ -506,6 +506,26 @@
           </svg>
         </button>
 
+        <button
+          @click="handleBatchReverseProxy(true)"
+          class="btn btn--icon btn--ghost"
+          v-tooltip="$t('platform.openai.batchEnableReverseProxy')"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 2l3 6 6 .9-4.5 4.4 1 6.2L12 17l-5.5 2.5 1-6.2L3 8.9 9 8z" />
+          </svg>
+        </button>
+
+        <button
+          @click="handleBatchReverseProxy(false)"
+          class="btn btn--icon btn--ghost"
+          v-tooltip="$t('platform.openai.batchDisableReverseProxy')"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M19 6.4L17.6 5 12 10.6 6.4 5 5 6.4l5.6 5.6L5 17.6 6.4 19l5.6-5.6 5.6 5.6 1.4-1.4-5.6-5.6z" />
+          </svg>
+        </button>
+
         <!-- 批量导出 -->
         <button
           @click="handleBatchExport"
@@ -612,6 +632,7 @@ import FixedPaginationLayout from '../common/FixedPaginationLayout.vue'
 import AccountManagerHeader from '../common/AccountManagerHeader.vue'
 import TagEditorModal from '../token/TagEditorModal.vue'
 import { useStorageSync } from '@/composables/useStorageSync'
+import { applyReverseProxyToSelection } from '@/utils/openaiReverseProxy'
 
 const { t: $t } = useI18n()
 let unlistenOpenAIAccountsUpdated = null
@@ -1326,6 +1347,41 @@ const batchRefreshSelected = async () => {
   }
 }
 
+const handleBatchReverseProxy = async (enabled) => {
+  if (selectedAccountIds.value.size === 0) return
+
+  const updatedCount = applyReverseProxyToSelection(
+    accounts.value,
+    selectedAccountIds.value,
+    enabled
+  )
+
+  if (updatedCount === 0) {
+    window.$notify?.error($t('platform.openai.messages.noReverseProxySelection'))
+    return
+  }
+
+  for (const account of accounts.value) {
+    if (selectedAccountIds.value.has(account.id) && account.account_type !== 'api') {
+      markItemUpsert(account)
+    }
+  }
+
+  try {
+    await invoke('openai_save_accounts', { accounts: accounts.value })
+    clearSelection()
+    refreshCodexPoolQuietly()
+    window.$notify?.success(
+      enabled
+        ? $t('platform.openai.messages.batchEnableReverseProxySuccess', { count: updatedCount })
+        : $t('platform.openai.messages.batchDisableReverseProxySuccess', { count: updatedCount })
+    )
+  } catch (error) {
+    console.error('Failed to batch update reverse proxy:', error)
+    window.$notify?.error($t('platform.openai.messages.updateFailed', { error: error?.message || error }))
+  }
+}
+
 const showBatchDeleteSelectedConfirm = () => {
   handleBatchDeleteSelected()
 }
@@ -1422,6 +1478,7 @@ const handleAccountUpdated = async (updatedAccount) => {
     }
     await invoke('openai_update_account', { account: updatedAccount })
     markItemUpsert(updatedAccount)
+    refreshCodexPoolQuietly()
   } catch (error) {
     console.error('Failed to update account:', error)
     window.$notify?.error($t('messages.updateFailed'))

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -1585,6 +1585,13 @@ export default {
       planType: 'Plan',
       subscriptionExpires: 'Subscription expires',
       reasoningEffort: 'Reasoning',
+      reverseProxy: 'Proxy',
+      enableReverseProxy: 'Enable reverse proxy',
+      disableReverseProxy: 'Disable reverse proxy',
+      reverseProxyEnabled: 'Reverse proxy enabled',
+      reverseProxyDisabled: 'Reverse proxy disabled',
+      reverseProxyEnabledSuccess: 'Reverse proxy enabled',
+      reverseProxyDisabledSuccess: 'Reverse proxy disabled',
       viewSyncQueueTooltip: 'Click to view pending sync queue',
       syncQueueTitle: 'Sync Queue',
       syncQueueUpsertsTitle: 'Pending Updates',
@@ -1594,6 +1601,8 @@ export default {
       sync: 'Sync',
       searchPlaceholder: 'Search email...',
       batchRefresh: 'Batch refresh',
+      batchEnableReverseProxy: 'Batch enable reverse proxy',
+      batchDisableReverseProxy: 'Batch disable reverse proxy',
       allAccountsMarkedForSync: 'All {count} accounts marked for sync',
       export: 'Export Accounts',
       exportSuccess: 'Accounts exported successfully',
@@ -1804,7 +1813,10 @@ export default {
         deleteFailed: 'Delete failed: {error}',
         batchDeleteConfirm: 'Are you sure you want to delete {count} selected accounts?',
         noSelection: 'Please select accounts to operate',
-        importSuccess: 'Successfully imported {count} accounts'
+        importSuccess: 'Successfully imported {count} accounts',
+        noReverseProxySelection: 'No eligible OAuth accounts in the current selection',
+        batchEnableReverseProxySuccess: 'Enabled reverse proxy for {count} accounts',
+        batchDisableReverseProxySuccess: 'Disabled reverse proxy for {count} accounts'
       }
     },
     claude: {

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -1592,6 +1592,18 @@ export default {
       reverseProxyDisabled: 'Reverse proxy disabled',
       reverseProxyEnabledSuccess: 'Reverse proxy enabled',
       reverseProxyDisabledSuccess: 'Reverse proxy disabled',
+      thirdPartyCredentials: {
+        openMenu: 'Copy third-party credentials',
+        title: 'Copy third-party credentials',
+        account: 'Account',
+        template: 'Template',
+        hint: 'Templates are built in. Select one and copy the generated content directly.',
+        preview: 'Preview',
+        copy: 'Copy content',
+        empty: 'No available third-party credential templates for this account',
+        copySuccess: '{name} credentials copied',
+        copyFailed: 'Failed to copy third-party credentials'
+      },
       viewSyncQueueTooltip: 'Click to view pending sync queue',
       syncQueueTitle: 'Sync Queue',
       syncQueueUpsertsTitle: 'Pending Updates',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -1585,6 +1585,18 @@ export default {
       reverseProxyDisabled: '已关闭反代',
       reverseProxyEnabledSuccess: '已启用反代',
       reverseProxyDisabledSuccess: '已关闭反代',
+      thirdPartyCredentials: {
+        openMenu: '复制第三方凭证',
+        title: '复制第三方凭证',
+        account: '当前账号',
+        template: '凭证模板',
+        hint: '模板为内置格式，选择后可直接复制对应内容。',
+        preview: '内容预览',
+        copy: '复制内容',
+        empty: '当前账号没有可用的第三方凭证模板',
+        copySuccess: '{name} 凭证已复制',
+        copyFailed: '复制第三方凭证失败'
+      },
       viewSyncQueueTooltip: '点击查看待同步队列',
       syncQueueTitle: '同步队列',
       syncQueueUpsertsTitle: '待更新',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -1578,6 +1578,13 @@ export default {
       planType: '订阅计划',
       subscriptionExpires: '订阅到期',
       reasoningEffort: '推理强度',
+      reverseProxy: '反代',
+      enableReverseProxy: '启用反代',
+      disableReverseProxy: '关闭反代',
+      reverseProxyEnabled: '已启用反代',
+      reverseProxyDisabled: '已关闭反代',
+      reverseProxyEnabledSuccess: '已启用反代',
+      reverseProxyDisabledSuccess: '已关闭反代',
       viewSyncQueueTooltip: '点击查看待同步队列',
       syncQueueTitle: '同步队列',
       syncQueueUpsertsTitle: '待更新',
@@ -1587,6 +1594,8 @@ export default {
       sync: '同步',
       searchPlaceholder: '搜索邮箱...',
       batchRefresh: '批量刷新',
+      batchEnableReverseProxy: '批量启用反代',
+      batchDisableReverseProxy: '批量关闭反代',
       allAccountsMarkedForSync: '已将 {count} 个账号标记为待同步',
       export: '导出账号',
       exportSuccess: '账号导出成功',
@@ -1797,7 +1806,10 @@ export default {
         deleteFailed: '删除失败: {error}',
         batchDeleteConfirm: '确定要删除选中的 {count} 个账号吗？',
         noSelection: '请先选择要操作的账号',
-        importSuccess: '成功导入 {count} 个账号'
+        importSuccess: '成功导入 {count} 个账号',
+        noReverseProxySelection: '选中的账号中没有可操作的 OAuth 账号',
+        batchEnableReverseProxySuccess: '已为 {count} 个账号启用反代',
+        batchDisableReverseProxySuccess: '已为 {count} 个账号关闭反代'
       }
     },
     claude: {

--- a/src/utils/openaiReverseProxy.js
+++ b/src/utils/openaiReverseProxy.js
@@ -1,0 +1,43 @@
+const isOAuthAccount = (account) => account?.account_type !== 'api'
+
+export const getReverseProxyAction = (account) => {
+  if (!isOAuthAccount(account)) {
+    return null
+  }
+
+  return account.reverse_proxy_enabled !== false ? 'disable' : 'enable'
+}
+
+export const toggleReverseProxyForAccount = (
+  account,
+  timestamp = Math.floor(Date.now() / 1000)
+) => {
+  if (!isOAuthAccount(account)) {
+    return false
+  }
+
+  account.reverse_proxy_enabled = !(account.reverse_proxy_enabled !== false)
+  account.updated_at = timestamp
+  return true
+}
+
+export const applyReverseProxyToSelection = (
+  accounts,
+  selectedAccountIds,
+  enabled,
+  timestamp = Math.floor(Date.now() / 1000)
+) => {
+  let updatedCount = 0
+
+  for (const account of accounts) {
+    if (!selectedAccountIds.has(account.id) || !isOAuthAccount(account)) {
+      continue
+    }
+
+    account.reverse_proxy_enabled = enabled
+    account.updated_at = timestamp
+    updatedCount++
+  }
+
+  return updatedCount
+}

--- a/src/utils/openaiThirdPartyCredentials.test.js
+++ b/src/utils/openaiThirdPartyCredentials.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildOpenAIThirdPartyCredentialPreview,
+  getAvailableOpenAIThirdPartyCredentialTemplates
+} from './openaiThirdPartyCredentials/index.js'
+
+const oauthAccount = {
+  id: 'acc-1',
+  email: 'user@example.com',
+  account_type: 'oauth',
+  chatgpt_account_id: 'fa8d225c-ee2a-4c1f-b4a8-16725740ddf6',
+  token: {
+    access_token: 'access-token-value',
+    refresh_token: 'refresh-token-value',
+    id_token: 'id-token-value'
+  }
+}
+
+test('只返回当前账号可用的第三方凭证模板', () => {
+  const templates = getAvailableOpenAIThirdPartyCredentialTemplates(oauthAccount)
+
+  assert.equal(templates.length, 1)
+  assert.equal(templates[0].id, 'cc-switch')
+})
+
+test('生成 cc-switch 凭证内容', () => {
+  const preview = buildOpenAIThirdPartyCredentialPreview(oauthAccount, 'cc-switch', {
+    now: '2026-04-11T15:22:16Z'
+  })
+
+  assert.deepEqual(JSON.parse(preview), {
+    OPENAI_API_KEY: null,
+    last_refresh: '2026-04-11T15:22:16Z',
+    tokens: {
+      access_token: 'access-token-value',
+      account_id: 'fa8d225c-ee2a-4c1f-b4a8-16725740ddf6',
+      id_token: 'id-token-value',
+      refresh_token: 'refresh-token-value'
+    }
+  })
+})
+
+test('缺少必要 token 时不提供 cc-switch 模板', () => {
+  const templates = getAvailableOpenAIThirdPartyCredentialTemplates({
+    ...oauthAccount,
+    token: {
+      access_token: 'access-token-value',
+      refresh_token: null,
+      id_token: 'id-token-value'
+    }
+  })
+
+  assert.deepEqual(templates, [])
+})

--- a/src/utils/openaiThirdPartyCredentials/index.js
+++ b/src/utils/openaiThirdPartyCredentials/index.js
@@ -1,0 +1,19 @@
+import ccSwitchCredential from './templates/ccSwitchCredential.js'
+
+const templates = [ccSwitchCredential]
+
+export const getAvailableOpenAIThirdPartyCredentialTemplates = (account) => {
+  return templates.filter((template) => template.supports(account))
+}
+
+export const getOpenAIThirdPartyCredentialTemplateById = (templateId) => {
+  return templates.find((template) => template.id === templateId) || null
+}
+
+export const buildOpenAIThirdPartyCredentialPreview = (account, templateId, context = {}) => {
+  const template = getOpenAIThirdPartyCredentialTemplateById(templateId)
+  if (!template) {
+    throw new Error(`Unknown third-party credential template: ${templateId}`)
+  }
+  return template.build(account, context)
+}

--- a/src/utils/openaiThirdPartyCredentials/templates/ccSwitchCredential.js
+++ b/src/utils/openaiThirdPartyCredentials/templates/ccSwitchCredential.js
@@ -1,0 +1,61 @@
+const formatIsoSeconds = (value = new Date()) => {
+  const date = value instanceof Date ? value : new Date(value)
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z')
+}
+
+const parseOpenAIAuthJson = (account) => {
+  if (!account?.openai_auth_json) return null
+  try {
+    return JSON.parse(account.openai_auth_json)
+  } catch {
+    return null
+  }
+}
+
+const resolveAccountId = (account) => {
+  const authInfo = parseOpenAIAuthJson(account)
+  return (
+    account?.chatgpt_account_id ??
+    authInfo?.chatgpt_account_id ??
+    authInfo?.['https://api.openai.com/auth']?.chatgpt_account_id ??
+    null
+  )
+}
+
+const hasRequiredTokens = (account) => {
+  const token = account?.token
+  return Boolean(
+    account?.account_type !== 'api' &&
+      token?.access_token &&
+      token?.refresh_token &&
+      token?.id_token
+  )
+}
+
+export default {
+  id: 'cc-switch',
+  label: 'cc-switch',
+  supports(account) {
+    return hasRequiredTokens(account)
+  },
+  build(account, context = {}) {
+    if (!hasRequiredTokens(account)) {
+      throw new Error('Account does not support cc-switch credentials')
+    }
+
+    return JSON.stringify(
+      {
+        OPENAI_API_KEY: null,
+        last_refresh: formatIsoSeconds(context.now),
+        tokens: {
+          access_token: account.token.access_token,
+          account_id: resolveAccountId(account),
+          id_token: account.token.id_token,
+          refresh_token: account.token.refresh_token
+        }
+      },
+      null,
+      2
+    )
+  }
+}


### PR DESCRIPTION
## 背景

在部分使用场景下，ATM 只用于集中管理大量 OpenAI 账号，但只有部分 OAuth 账号需要实际参与 API 反代 / Codex 路由。

当前缺少账号级别的反代控制能力，导致被管理的 OAuth 账号会一起进入 Codex 账号池，不方便按需隔离。

## 改动内容

- 为 OpenAI OAuth 账号增加 `reverse_proxy_enabled` 开关，默认值为 `true`
- 增加数据库迁移、模型字段和存储映射
- 调整 Codex 账号池筛选逻辑，仅使用开启反代的 OAuth 账号
- 优化 `Single` 策略，在选中账号不可用时回退到第一个可用账号
- 前端增加单条和批量反代操作，并保持现有样式与交互逻辑一致

## 兼容性

- 仅影响 OAuth 账号
- API 账号不受影响
- 默认值为开启，兼容现有行为

## 验证

- 已验证单条反代切换
- 已验证批量启用 / 关闭反代
- 已验证 Codex 仅从开启反代的账号中筛选
- 已完成本地构建并生成可执行文件测试
