### PR TITLE
fix(outlook, openai): 修复 Outlook 和 OpenAI 模块中验证码获取后自动复制失败的问题

### DIFF
--- a/src/components/email/OutlookManager.vue
+++ b/src/components/email/OutlookManager.vue
@@ -718,7 +718,12 @@ const fetchVerificationCode = async (email) => {
       return
     }
 
-    await navigator.clipboard.writeText(code)
+    try {
+      await invoke('copy_to_clipboard', { text: code })
+    } catch (nativeErr) {
+      console.warn('Native clipboard failed, falling back to browser clipboard:', nativeErr)
+      await navigator.clipboard.writeText(code)
+    }
     showStatus(`验证码 ${code} 已复制`, 'success')
   } catch (error) {
     console.error('Fetch Outlook verification code failed:', error)

--- a/src/components/openai/AddAccountDialog.vue
+++ b/src/components/openai/AddAccountDialog.vue
@@ -502,7 +502,12 @@ const loadOutlookAccounts = async () => {
 }
 
 const copyCodeToClipboard = async (code) => {
-  await navigator.clipboard.writeText(code)
+  try {
+    await invoke('copy_to_clipboard', { text: code })
+  } catch (nativeErr) {
+    console.warn('Native clipboard failed, falling back to browser clipboard:', nativeErr)
+    await navigator.clipboard.writeText(code)
+  }
 }
 
 const fetchVerificationCode = async () => {


### PR DESCRIPTION
## 变更概述

修复 Outlook 邮箱管理和 OpenAI 添加账号流程中，在异步拉取邮件后自动复制验证码失败的问题。

## 变更原因

在 macOS 的 Tauri WebView 环境下，`navigator.clipboard.writeText` 在异步获取邮件之后可能因为原始用户手势丢失而失败。  
这会导致验证码虽然已经成功获取，但自动复制到剪贴板的步骤失败。

## 具体改动

- 调整 Outlook 邮箱管理中的验证码复制逻辑：
  - 优先调用已有的 Tauri 原生剪贴板命令
  - 如果原生复制失败，再回退到浏览器剪贴板 API
- 调整 OpenAI 添加账号流程中的验证码复制逻辑：
  - 与 Outlook 保持一致，采用相同的原生优先、浏览器兜底策略

## 影响范围

- `src/components/email/OutlookManager.vue`
- `src/components/openai/AddAccountDialog.vue`

## 验证情况

已完成以下验证：

```bash
npm run build