### PR TITLE
feat(openai): 支持仅通过 AT 导入并补全订阅到期信息

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -605,6 +605,7 @@ pub fn run() {
             openai::openai_refresh_all_tokens,
             openai::openai_load_accounts_json,
             openai::openai_add_account,
+            openai::openai_add_account_with_access_token,
             openai::openai_import_account_direct,
             openai::openai_add_api_account,
             openai::openai_update_api_account,

--- a/src-tauri/src/platforms/openai/commands.rs
+++ b/src-tauri/src/platforms/openai/commands.rs
@@ -458,6 +458,63 @@ pub async fn openai_add_account(app: AppHandle, refresh_token: String) -> Result
     Ok(account)
 }
 
+/// 添加账号（仅使用 access_token，账号信息从原始 AT 或 session JSON 本地解析）
+#[tauri::command]
+pub async fn openai_add_account_with_access_token(
+    app: AppHandle,
+    access_token: String,
+) -> Result<Account, String> {
+    let mut import = oauth::parse_access_token_import_input(&access_token)?;
+    oauth::enrich_access_token_import_with_account_check(&mut import).await;
+    let chatgpt_account_id = import.chatgpt_account_id.clone();
+    let email = import
+        .email
+        .as_ref()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .or_else(|| chatgpt_account_id.clone())
+        .ok_or_else(|| "Failed to get account identity from access token".to_string())?;
+
+    let existing_accounts = storage::list_accounts(&app).await.unwrap_or_default();
+
+    println!("=== OpenAI Add Account With Access Token ===");
+    println!("Email: {}", email);
+    println!("ChatGPT Account ID: {:?}", chatgpt_account_id);
+
+    if Account::is_duplicate(&email, &chatgpt_account_id, &existing_accounts) {
+        return Err("该账号已存在".to_string());
+    }
+
+    let unique_email =
+        Account::generate_unique_email(&email, &chatgpt_account_id, &existing_accounts);
+
+    let now = chrono::Utc::now().timestamp();
+    let expires_at = import.expires_at.unwrap_or(now + 864000);
+    let expires_in = (expires_at - now).max(0);
+
+    let token = TokenData::new(
+        import.access_token,
+        None,
+        None,
+        expires_in,
+        expires_at,
+        Some("Bearer".to_string()),
+    );
+
+    let mut account = Account::new_oauth(
+        unique_email,
+        token,
+        chatgpt_account_id,
+        import.chatgpt_user_id,
+        import.organization_id,
+    );
+    account.openai_auth_json = import.openai_auth_json;
+
+    storage::save_account(&app, &account).await?;
+
+    Ok(account)
+}
+
 /// 从 JWT 的 payload 中解析 exp 字段
 fn parse_jwt_exp(jwt: &str) -> Option<i64> {
     let payload = jwt.split('.').nth(1)?;

--- a/src-tauri/src/platforms/openai/modules/account.rs
+++ b/src-tauri/src/platforms/openai/modules/account.rs
@@ -91,7 +91,40 @@ pub async fn refresh_quota_and_backfill(account: &mut Account) -> Result<QuotaDa
     let quota = fetch_quota_with_retry(account).await?;
     account.update_quota(quota.clone());
     backfill_openai_auth_json_if_missing(account);
+
+    if missing_subscription_expiry(account) {
+        if let Some(access_token) = account
+            .token
+            .as_ref()
+            .map(|token| token.access_token.clone())
+        {
+            oauth::enrich_openai_auth_json_with_account_check(
+                &access_token,
+                account.organization_id.as_deref(),
+                account.chatgpt_account_id.as_deref(),
+                &mut account.openai_auth_json,
+            )
+            .await;
+        }
+    }
+
     Ok(quota)
+}
+
+fn missing_subscription_expiry(account: &Account) -> bool {
+    account
+        .openai_auth_json
+        .as_deref()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
+        .and_then(|value| {
+            value
+                .get("chatgpt_subscription_active_until")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .map(|value| !value.is_empty())
+        })
+        .map(|has_value| !has_value)
+        .unwrap_or(true)
 }
 
 pub async fn refresh_token_if_needed(

--- a/src-tauri/src/platforms/openai/modules/oauth.rs
+++ b/src-tauri/src/platforms/openai/modules/oauth.rs
@@ -1,6 +1,7 @@
 use base64::{Engine as _, engine::general_purpose};
 use chrono::Utc;
 use rand::Rng;
+use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
@@ -17,6 +18,8 @@ const DEFAULT_REDIRECT_URI: &str = "http://localhost:1455/auth/callback";
 const DEFAULT_SCOPES: &str = "openid profile email offline_access";
 const REFRESH_SCOPES: &str = "openid profile email";
 const SESSION_TTL_SECS: u64 = 30 * 60;
+const CHATGPT_ACCOUNTS_CHECK_URL: &str =
+    "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27";
 
 fn generate_random_bytes(length: usize) -> Vec<u8> {
     let mut rng = rand::thread_rng();
@@ -198,6 +201,376 @@ pub fn extract_openai_auth_json(id_token: &str) -> Option<String> {
     let claims: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
     let auth_obj = claims.get("https://api.openai.com/auth")?.as_object()?;
     serde_json::to_string(auth_obj).ok()
+}
+
+fn decode_jwt_payload(jwt: &str) -> Option<Value> {
+    let payload = jwt.split('.').nth(1)?;
+    let decoded = general_purpose::URL_SAFE_NO_PAD
+        .decode(payload.as_bytes())
+        .or_else(|_| {
+            let mut padded = payload.to_string();
+            let remainder = padded.len() % 4;
+            if remainder != 0 {
+                padded.push_str(&"=".repeat(4 - remainder));
+            }
+            general_purpose::URL_SAFE.decode(padded.as_bytes())
+        })
+        .ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+fn organization_id_from_auth(auth: &Value) -> Option<String> {
+    if let Some(poid) = auth
+        .get("poid")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        return Some(poid.to_string());
+    }
+
+    let orgs = auth.get("organizations")?.as_array()?;
+    let selected = orgs
+        .iter()
+        .find(|org| {
+            org.get("is_default")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+        })
+        .or_else(|| orgs.first())?;
+    selected.get("id")?.as_str().map(ToOwned::to_owned)
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenAIAccessTokenImport {
+    pub access_token: String,
+    pub email: Option<String>,
+    pub chatgpt_account_id: Option<String>,
+    pub chatgpt_user_id: Option<String>,
+    pub organization_id: Option<String>,
+    pub openai_auth_json: Option<String>,
+    pub expires_at: Option<i64>,
+}
+
+fn trimmed_value_string(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn set_auth_json_string(auth: &mut Map<String, Value>, key: &str, value: &Option<String>) {
+    if let Some(value) = value.as_ref().map(|v| v.trim()).filter(|v| !v.is_empty()) {
+        auth.insert(key.to_string(), Value::String(value.to_string()));
+    }
+}
+
+fn extract_auth_map_from_claims(claims: &Value) -> Map<String, Value> {
+    claims
+        .get("https://api.openai.com/auth")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Clone, Default)]
+struct AccountCheckEnrichment {
+    plan_type: Option<String>,
+    subscription_expires_at: Option<String>,
+}
+
+fn extract_account_plan_type(account: &Map<String, Value>) -> Option<String> {
+    account
+        .get("account")
+        .and_then(Value::as_object)
+        .and_then(|v| trimmed_value_string(v.get("plan_type")))
+        .or_else(|| {
+            account
+                .get("entitlement")
+                .and_then(Value::as_object)
+                .and_then(|v| trimmed_value_string(v.get("subscription_plan")))
+        })
+}
+
+fn extract_account_subscription_expires_at(account: &Map<String, Value>) -> Option<String> {
+    account
+        .get("entitlement")
+        .and_then(Value::as_object)
+        .and_then(|v| v.get("expires_at"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn build_account_check_enrichment(account: &Map<String, Value>) -> AccountCheckEnrichment {
+    AccountCheckEnrichment {
+        plan_type: extract_account_plan_type(account),
+        subscription_expires_at: extract_account_subscription_expires_at(account),
+    }
+}
+
+fn extract_account_check_enrichment(
+    value: &Value,
+    preferred_account_ids: &[Option<&str>],
+) -> AccountCheckEnrichment {
+    let Some(accounts) = value.get("accounts").and_then(Value::as_object) else {
+        return AccountCheckEnrichment::default();
+    };
+
+    for account_id in preferred_account_ids
+        .iter()
+        .filter_map(|v| v.map(str::trim))
+        .filter(|v| !v.is_empty())
+    {
+        if let Some(account) = accounts.get(account_id).and_then(Value::as_object) {
+            let enrichment = build_account_check_enrichment(account);
+            if enrichment.plan_type.is_some() {
+                return enrichment;
+            }
+        }
+    }
+
+    let mut default_candidate = AccountCheckEnrichment::default();
+    let mut paid_candidate = AccountCheckEnrichment::default();
+    let mut any_candidate = AccountCheckEnrichment::default();
+
+    for account in accounts.values().filter_map(Value::as_object) {
+        let enrichment = build_account_check_enrichment(account);
+        let Some(plan_type) = enrichment.plan_type.as_deref() else {
+            continue;
+        };
+
+        if any_candidate.plan_type.is_none() {
+            any_candidate = enrichment.clone();
+        }
+
+        let is_default = account
+            .get("account")
+            .and_then(Value::as_object)
+            .and_then(|v| v.get("is_default"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if is_default {
+            default_candidate = enrichment.clone();
+        }
+
+        if !plan_type.eq_ignore_ascii_case("free") && paid_candidate.plan_type.is_none() {
+            paid_candidate = enrichment;
+        }
+    }
+
+    if default_candidate.plan_type.is_some() {
+        default_candidate
+    } else if paid_candidate.plan_type.is_some() {
+        paid_candidate
+    } else {
+        any_candidate
+    }
+}
+
+fn merge_account_check_enrichment_into_auth_json(
+    openai_auth_json: &mut Option<String>,
+    enrichment: AccountCheckEnrichment,
+) {
+    if enrichment.plan_type.is_none() && enrichment.subscription_expires_at.is_none() {
+        return;
+    }
+
+    let mut auth_json = openai_auth_json
+        .as_deref()
+        .and_then(|v| serde_json::from_str::<Value>(v).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+
+    set_auth_json_string(&mut auth_json, "chatgpt_plan_type", &enrichment.plan_type);
+    set_auth_json_string(
+        &mut auth_json,
+        "chatgpt_subscription_active_until",
+        &enrichment.subscription_expires_at,
+    );
+
+    if !auth_json.is_empty() {
+        *openai_auth_json = serde_json::to_string(&auth_json).ok();
+    }
+}
+
+pub async fn enrich_openai_auth_json_with_account_check(
+    access_token: &str,
+    organization_id: Option<&str>,
+    chatgpt_account_id: Option<&str>,
+    openai_auth_json: &mut Option<String>,
+) {
+    let client = match create_proxy_client() {
+        Ok(client) => client,
+        Err(e) => {
+            println!("OpenAI accounts/check client creation failed: {}", e);
+            return;
+        }
+    };
+
+    let response = match client
+        .get(CHATGPT_ACCOUNTS_CHECK_URL)
+        .header("authorization", format!("Bearer {}", access_token))
+        .header("origin", "https://chatgpt.com")
+        .header("referer", "https://chatgpt.com/")
+        .header("accept", "application/json")
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(e) => {
+            println!("OpenAI accounts/check request failed: {}", e);
+            return;
+        }
+    };
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        println!(
+            "OpenAI accounts/check failed: status={}, body={}",
+            status,
+            body.chars().take(200).collect::<String>()
+        );
+        return;
+    }
+
+    let value = match response.json::<Value>().await {
+        Ok(value) => value,
+        Err(e) => {
+            println!("OpenAI accounts/check response parse failed: {}", e);
+            return;
+        }
+    };
+
+    let preferred_account_ids = [organization_id, chatgpt_account_id];
+    let enrichment = extract_account_check_enrichment(&value, &preferred_account_ids);
+    merge_account_check_enrichment_into_auth_json(openai_auth_json, enrichment);
+}
+
+pub async fn enrich_access_token_import_with_account_check(import: &mut OpenAIAccessTokenImport) {
+    enrich_openai_auth_json_with_account_check(
+        &import.access_token,
+        import.organization_id.as_deref(),
+        import.chatgpt_account_id.as_deref(),
+        &mut import.openai_auth_json,
+    )
+    .await;
+}
+
+pub fn parse_access_token_import_input(input: &str) -> Result<OpenAIAccessTokenImport, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("Access Token cannot be empty".to_string());
+    }
+
+    let parsed_json = serde_json::from_str::<Value>(trimmed).ok();
+    let session_json = match parsed_json.as_ref() {
+        Some(Value::Object(_)) => parsed_json.as_ref(),
+        Some(_) => {
+            return Err("Only raw Access Token or /api/auth/session JSON is supported".to_string());
+        }
+        None => None,
+    };
+
+    let access_token = match session_json {
+        Some(value) => trimmed_value_string(value.get("accessToken"))
+            .ok_or_else(|| "Missing accessToken in /api/auth/session JSON".to_string())?,
+        None => trimmed.to_string(),
+    };
+
+    let claims = decode_jwt_payload(&access_token);
+    let auth_claims = claims
+        .as_ref()
+        .and_then(|v| v.get("https://api.openai.com/auth"));
+    let profile_claims = claims
+        .as_ref()
+        .and_then(|v| v.get("https://api.openai.com/profile"));
+
+    let mut email = session_json
+        .and_then(|value| value.get("user"))
+        .and_then(|user| trimmed_value_string(user.get("email")))
+        .or_else(|| {
+            profile_claims
+                .and_then(|v| trimmed_value_string(v.get("email")))
+                .or_else(|| {
+                    claims
+                        .as_ref()
+                        .and_then(|v| trimmed_value_string(v.get("email")))
+                })
+        });
+
+    let chatgpt_account_id = session_json
+        .and_then(|value| value.get("account"))
+        .and_then(|account| trimmed_value_string(account.get("id")))
+        .or_else(|| auth_claims.and_then(|v| trimmed_value_string(v.get("chatgpt_account_id"))));
+
+    let chatgpt_user_id = session_json
+        .and_then(|value| value.get("user"))
+        .and_then(|user| trimmed_value_string(user.get("id")))
+        .or_else(|| {
+            auth_claims
+                .and_then(|v| trimmed_value_string(v.get("chatgpt_user_id")))
+                .or_else(|| auth_claims.and_then(|v| trimmed_value_string(v.get("user_id"))))
+                .or_else(|| {
+                    claims
+                        .as_ref()
+                        .and_then(|v| trimmed_value_string(v.get("sub")))
+                })
+        });
+
+    let organization_id = auth_claims.and_then(organization_id_from_auth);
+
+    let plan_type = session_json
+        .and_then(|value| value.get("account"))
+        .and_then(|account| trimmed_value_string(account.get("planType")))
+        .or_else(|| auth_claims.and_then(|v| trimmed_value_string(v.get("chatgpt_plan_type"))));
+
+    let compute_residency = session_json
+        .and_then(|value| value.get("account"))
+        .and_then(|account| trimmed_value_string(account.get("computeResidency")))
+        .or_else(|| {
+            auth_claims.and_then(|v| trimmed_value_string(v.get("chatgpt_compute_residency")))
+        });
+
+    let expires_at = claims
+        .as_ref()
+        .and_then(|v| v.get("exp"))
+        .and_then(Value::as_i64);
+
+    let mut auth_json = claims
+        .as_ref()
+        .map(extract_auth_map_from_claims)
+        .unwrap_or_default();
+    set_auth_json_string(&mut auth_json, "chatgpt_account_id", &chatgpt_account_id);
+    set_auth_json_string(&mut auth_json, "chatgpt_user_id", &chatgpt_user_id);
+    set_auth_json_string(&mut auth_json, "user_id", &chatgpt_user_id);
+    set_auth_json_string(&mut auth_json, "chatgpt_plan_type", &plan_type);
+    set_auth_json_string(
+        &mut auth_json,
+        "chatgpt_compute_residency",
+        &compute_residency,
+    );
+
+    if email.is_none() {
+        email = chatgpt_user_id.clone();
+    }
+
+    let openai_auth_json = if auth_json.is_empty() {
+        None
+    } else {
+        serde_json::to_string(&auth_json).ok()
+    };
+
+    Ok(OpenAIAccessTokenImport {
+        access_token,
+        email,
+        chatgpt_account_id,
+        chatgpt_user_id,
+        organization_id,
+        openai_auth_json,
+        expires_at,
+    })
 }
 
 pub fn build_token_info(

--- a/src/components/openai/AccountCard.vue
+++ b/src/components/openai/AccountCard.vue
@@ -47,17 +47,21 @@
       @click.stop
     >
       <!-- 切换按钮 -->
-      <button
-        @click="$emit('switch', account.id)"
-        class="w-7 h-7 rounded border-none bg-surface text-text-secondary cursor-pointer flex items-center justify-center shadow-sm hover:bg-hover hover:text-accent transition-colors"
-        :disabled="isSwitching"
-        v-tooltip="$t('platform.openai.switch')"
-      >
-        <svg v-if="!isSwitching" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/>
-        </svg>
-        <span v-else class="btn-spinner btn-spinner--sm text-accent"></span>
-      </button>
+      <span v-tooltip="switchTooltip" class="inline-flex">
+        <button
+          @click="$emit('switch', account.id)"
+          :class="[
+            'w-7 h-7 rounded border-none bg-surface text-text-secondary flex items-center justify-center shadow-sm transition-colors',
+            switchDisabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-hover hover:text-accent'
+          ]"
+          :disabled="switchDisabled"
+        >
+          <svg v-if="!isSwitching" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z"/>
+          </svg>
+          <span v-else class="btn-spinner btn-spinner--sm text-accent"></span>
+        </button>
+      </span>
 
       <!-- 刷新配额按钮 (仅 OAuth 账号) -->
       <button
@@ -411,6 +415,19 @@ const menuRef = ref(null)
 const showTagEditor = ref(false)
 const isMenuOpen = ref(false)
 const DEFAULT_TAG_COLOR = '#f97316'
+
+const isAccessTokenOnlyAccount = computed(() => {
+  const token = props.account?.token
+  return props.account?.account_type !== 'api' && Boolean(token?.access_token) && !token?.refresh_token
+})
+
+const switchDisabled = computed(() => props.isSwitching || isAccessTokenOnlyAccount.value)
+
+const switchTooltip = computed(() => (
+  isAccessTokenOnlyAccount.value
+    ? $t('platform.openai.actions.switchDisabledAccessTokenOnly')
+    : $t('platform.openai.switch')
+))
 
 // 状态相关
 const statusClass = computed(() => {

--- a/src/components/openai/AccountTableRow.vue
+++ b/src/components/openai/AccountTableRow.vue
@@ -156,17 +156,18 @@
     <td class="px-2.5 py-3.5 border-b border-border/50 align-middle whitespace-nowrap text-[13px] text-text">
       <div class="flex items-center gap-1.5 justify-end">
         <!-- 切换按钮 -->
-        <button
-          @click.stop="$emit('switch', account.id)"
-          class="btn btn--ghost btn--icon-sm"
-          :disabled="isSwitching"
-          v-tooltip="$t('platform.openai.actions.switch')"
-        >
-          <svg v-if="!isSwitching" class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z" />
-          </svg>
-          <span v-else class="btn-spinner btn-spinner--xs text-accent" aria-hidden="true"></span>
-        </button>
+        <span v-tooltip="switchTooltip" class="inline-flex">
+          <button
+            @click.stop="$emit('switch', account.id)"
+            class="btn btn--ghost btn--icon-sm"
+            :disabled="switchDisabled"
+          >
+            <svg v-if="!isSwitching" class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z" />
+            </svg>
+            <span v-else class="btn-spinner btn-spinner--xs text-accent" aria-hidden="true"></span>
+          </button>
+        </span>
 
         <!-- 刷新配额按钮（仅 OAuth 账号） -->
         <button
@@ -305,6 +306,19 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['refresh', 'refresh-quota', 'delete', 'select', 'switch', 'account-updated', 'copy-third-party-credentials'])
+
+const isAccessTokenOnlyAccount = computed(() => {
+  const token = props.account?.token
+  return props.account?.account_type !== 'api' && Boolean(token?.access_token) && !token?.refresh_token
+})
+
+const switchDisabled = computed(() => props.isSwitching || isAccessTokenOnlyAccount.value)
+
+const switchTooltip = computed(() => (
+  isAccessTokenOnlyAccount.value
+    ? $t('platform.openai.actions.switchDisabledAccessTokenOnly')
+    : $t('platform.openai.actions.switch')
+))
 
 // 复制菜单状态
 const copyMenuRef = ref(null)

--- a/src/components/openai/AddAccountDialog.vue
+++ b/src/components/openai/AddAccountDialog.vue
@@ -273,7 +273,34 @@
 
     <!-- 手动添加方式 -->
     <div v-else-if="addMethod === 'manual'" class="animate-fade-in">
-      <div class="form-group mb-0">
+      <div class="mb-4 flex gap-2 rounded-lg bg-muted p-1">
+        <button
+          type="button"
+          :class="[
+            'flex flex-1 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-all',
+            manualTokenType === 'refresh_token'
+              ? 'bg-surface text-accent shadow-sm'
+              : 'text-text-secondary hover:bg-hover hover:text-text'
+          ]"
+          @click="manualTokenType = 'refresh_token'"
+        >
+          Refresh Token
+        </button>
+        <button
+          type="button"
+          :class="[
+            'flex flex-1 items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition-all',
+            manualTokenType === 'access_token'
+              ? 'bg-surface text-accent shadow-sm'
+              : 'text-text-secondary hover:bg-hover hover:text-text'
+          ]"
+          @click="manualTokenType = 'access_token'"
+        >
+          Access Token / Session JSON
+        </button>
+      </div>
+
+      <div v-if="manualTokenType === 'refresh_token'" class="form-group mb-0">
         <label class="label">{{ $t('platform.openai.addAccountDialog.refreshToken') }}</label>
         <textarea
           v-model="refreshToken"
@@ -285,6 +312,23 @@
         <p class="mt-1.5 text-xs text-text-muted">
           {{ $t('platform.openai.addAccountDialog.refreshTokenHint') }}
         </p>
+      </div>
+
+      <div v-else class="form-group mb-0">
+        <label class="label">{{ $t('platform.openai.addAccountDialog.accessToken') }}</label>
+        <textarea
+          v-model="accessToken"
+          :placeholder="$t('platform.openai.addAccountDialog.accessTokenPlaceholder')"
+          class="input resize-none"
+          rows="8"
+          :disabled="isLoading"
+        ></textarea>
+        <p v-if="$t('platform.openai.addAccountDialog.accessTokenHint')" class="mt-1.5 text-xs text-text-muted">
+          {{ $t('platform.openai.addAccountDialog.accessTokenHint') }}
+        </p>
+        <div class="mt-3 rounded-lg border border-warning/30 bg-warning/10 p-3 text-xs text-text-secondary">
+          {{ $t('platform.openai.addAccountDialog.accessTokenWarning') }}
+        </div>
       </div>
     </div>
 
@@ -439,7 +483,9 @@ const handleClose = async () => {
 }
 
 const addMethod = ref('oauth') // 'oauth', 'manual', or 'api'
+const manualTokenType = ref('refresh_token') // 'refresh_token' or 'access_token'
 const refreshToken = ref('')
+const accessToken = ref('')
 const isLoading = ref(false)
 const isOAuthLoginActive = ref(false)
 const isManualLoading = ref(false)
@@ -632,7 +678,8 @@ const selectedReasoningEffort = ref('medium')
 const selectedWireApi = ref('responses')
 
 const canSubmit = computed(() => {
-  if (addMethod.value === 'oauth') return true
+  if (addMethod.value !== 'manual') return false
+  if (manualTokenType.value === 'access_token') return accessToken.value.trim()
   return refreshToken.value.trim()
 })
 
@@ -801,9 +848,13 @@ const handleAdd = async () => {
   isLoading.value = true
 
   try {
-    const account = await invoke('openai_add_account', {
-      refreshToken: refreshToken.value.trim()
-    })
+    const account = manualTokenType.value === 'access_token'
+      ? await invoke('openai_add_account_with_access_token', {
+          accessToken: accessToken.value.trim()
+        })
+      : await invoke('openai_add_account', {
+          refreshToken: refreshToken.value.trim()
+        })
     emit('added', account)
   } catch (err) {
     console.error('Add account error:', err)

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -1676,7 +1676,11 @@ export default {
         emailPlaceholder: "your-email{'@'}example.com",
         refreshToken: 'Refresh Token',
         refreshTokenPlaceholder: 'Paste your Refresh Token here...',
-        refreshTokenHint: 'Get refresh_token from OpenAI database or network requests',
+        refreshTokenHint: 'Use Refresh Token to add the account. Access Token can be refreshed automatically. Recommended.',
+        accessToken: 'Access Token / Session JSON',
+        accessTokenPlaceholder: 'Paste an Access Token, or the JSON returned by chatgpt.com/api/auth/session...',
+        accessTokenHint: '',
+        accessTokenWarning: 'Note: if no Refresh Token is included, only the current Access Token is saved. Re-import after it expires.',
         adding: 'Adding...',
         add: 'Add Account',
         // API account related

--- a/src/locales/en-US.js
+++ b/src/locales/en-US.js
@@ -1648,6 +1648,7 @@ export default {
       rtInvalidReused: 'RefreshToken expired (re-add required)',
       actions: {
         switch: 'Switch account',
+        switchDisabledAccessTokenOnly: 'Accounts imported with only an Access Token cannot be switched. Re-import with a Refresh Token to enable switching.',
         refresh: 'Refresh account',
         refreshQuota: 'Refresh Quota',
         refreshToken: 'Refresh Token',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -1641,6 +1641,7 @@ export default {
       rtInvalidReused: 'RefreshToken已失效(需重新添加)',
       actions: {
         switch: '切换账号',
+        switchDisabledAccessTokenOnly: '仅通过 Access Token 导入的账号无法切换，请重新导入包含 Refresh Token 的账号',
         refresh: '刷新账号',
         refreshQuota: '刷新配额',
         refreshToken: '刷新 Token',

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -1669,7 +1669,11 @@ export default {
         emailPlaceholder: "your-email{'@'}example.com",
         refreshToken: 'Refresh Token',
         refreshTokenPlaceholder: '粘贴你的 Refresh Token...',
-        refreshTokenHint: '从 OpenAI 的数据库或网络请求中获取 refresh_token',
+        refreshTokenHint: '使用 Refresh Token 添加，可自动刷新 Access Token，推荐。',
+        accessToken: 'Access Token / Session JSON',
+        accessTokenPlaceholder: '粘贴 Access Token，或粘贴 chatgpt.com/api/auth/session 返回的 JSON...',
+        accessTokenHint: '',
+        accessTokenWarning: '注意：未包含 Refresh Token 时仅保存当前 Access Token，过期后无法自动刷新，需要重新导入。',
         adding: '添加中...',
         add: '添加账号',
         // API 账号相关

--- a/src/utils/openaiThirdPartyCredentials/templates/ccSwitchCredential.js
+++ b/src/utils/openaiThirdPartyCredentials/templates/ccSwitchCredential.js
@@ -26,9 +26,7 @@ const hasRequiredTokens = (account) => {
   const token = account?.token
   return Boolean(
     account?.account_type !== 'api' &&
-      token?.access_token &&
-      token?.refresh_token &&
-      token?.id_token
+      token?.access_token
   )
 }
 
@@ -50,8 +48,8 @@ export default {
         tokens: {
           access_token: account.token.access_token,
           account_id: resolveAccountId(account),
-          id_token: account.token.id_token,
-          refresh_token: account.token.refresh_token
+          id_token: account.token.id_token || '',
+          refresh_token: account.token.refresh_token || ''
         }
       },
       null,

--- a/src/utils/openaiThirdPartyCredentials/templates/cpaCredential.js
+++ b/src/utils/openaiThirdPartyCredentials/templates/cpaCredential.js
@@ -21,8 +21,7 @@ const hasRequiredTokens = (account) => {
   const token = account?.token
   return Boolean(
     account?.account_type !== 'api' &&
-      token?.access_token &&
-      token?.refresh_token
+      token?.access_token
   )
 }
 
@@ -43,7 +42,7 @@ export default {
         email: account.email || '',
         account_id: resolveAccountId(account) || '',
         access_token: account.token.access_token,
-        refresh_token: account.token.refresh_token,
+        refresh_token: account.token.refresh_token || '',
         id_token: account.token.id_token || ''
       },
       null,


### PR DESCRIPTION
## 变更概述

支持 OpenAI 账号在没有 Refresh Token 的情况下，通过 Access Token 或 `chatgpt.com/api/auth/session` 返回的 JSON 手动导入，并补全订阅计划和订阅到期信息。

## 变更原因

当前 OpenAI 手动添加流程依赖 Refresh Token，但部分场景只能拿到 Access Token 或 Web Session JSON。  
如果只保存 AT，本地账号缺少订阅到期字段，前端无法展示“订阅到期”，第三方凭证导出也会因为缺少 RT/ID Token 受限。

## 具体改动

- 调整 OpenAI 手动添加账号交互：
  - 保留原有 Refresh Token 添加方式
  - 新增 Access Token / Session JSON 输入方式
- 新增 AT-only 导入后端逻辑：
  - 支持原始 Access Token
  - 支持 `chatgpt.com/api/auth/session` 返回的 JSON
  - 从 AT/session 本地解析邮箱、账号 ID、用户 ID、套餐和 AT 到期时间
- 补全订阅信息获取逻辑：
  - 调用 `https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27`
  - 从 `account.plan_type` / `entitlement.subscription_plan` 补全套餐
  - 从 `entitlement.expires_at` 补全订阅到期
  - 写入 `openai_auth_json.chatgpt_subscription_active_until`
- 刷新配额时，如果账号缺失订阅到期信息，会 best-effort 回填
- 调整第三方凭证导出模板：
  - 仅有 `access_token` 时也允许复制
  - 缺失的 `refresh_token` / `id_token` 使用空字符串
- 禁用仅 Access Token 导入账号的切换入口：
  - 防止缺少 Refresh Token 的账号写入 Codex auth
  - 鼠标悬停时提示无法切换原因

## 影响范围

- `src/components/openai/AddAccountDialog.vue`
- `src-tauri/src/platforms/openai/commands.rs`
- `src-tauri/src/platforms/openai/modules/oauth.rs`
- `src-tauri/src/platforms/openai/modules/account.rs`
- `src-tauri/src/lib.rs`
- `src/locales/zh-CN.js`
- `src/locales/en-US.js`
- `src/utils/openaiThirdPartyCredentials/templates/ccSwitchCredential.js`
- `src/utils/openaiThirdPartyCredentials/templates/cpaCredential.js`

## 验证情况

已完成以下验证：

```bash
cargo check --lib
npm run build
npm run tauri -- build --bundles app
```