### PR TITLE
fix(openai): 修复订阅到期判断仅检查字段是否为空而未比对实际日期

### DIFF
--- a/src-tauri/src/platforms/openai/commands.rs
+++ b/src-tauri/src/platforms/openai/commands.rs
@@ -172,10 +172,11 @@ pub async fn openai_fetch_quota(app: AppHandle, account_id: String) -> Result<Ac
         return Err("API accounts do not support quota fetching".to_string());
     }
 
-    match account_module::fetch_quota_with_retry(&mut acc).await {
-        Ok(quota) => {
-            println!("Fetched quota: {:?}", quota);
-            acc.update_quota(quota);
+    // 使用 refresh_quota_and_backfill 统一刷新配额和订阅信息，
+    // 当本地存储的到期日过期时，会自动通过 accounts/check API 更新。
+    match account_module::refresh_quota_and_backfill(&mut acc).await {
+        Ok(_) => {
+            println!("Fetched quota and refreshed account info");
         }
         Err(e) => {
             println!("Quota fetch failed: {}", e);
@@ -185,7 +186,6 @@ pub async fn openai_fetch_quota(app: AppHandle, account_id: String) -> Result<Ac
         }
     }
 
-    account_module::backfill_openai_auth_json_if_missing(&mut acc);
     storage::save_account(&app, &acc).await?;
     println!("Updated account quota");
 
@@ -277,6 +277,27 @@ pub async fn openai_refresh_account_token(
         account_module::refresh_token_if_needed(&mut account, window_secs, force).await?;
     if refreshed {
         account_module::backfill_openai_auth_json_if_missing(&mut account);
+    }
+
+    // 无论 token 是否刷新，都要检查订阅信息是否过期。
+    // JWT 中的到期日可能是上个账单周期的快照，需要实际调用 API 获取真实数据。
+    if account_module::missing_subscription_expiry(&account) {
+        if let Some(access_token) = account
+            .token
+            .as_ref()
+            .map(|token| token.access_token.clone())
+        {
+            crate::platforms::openai::modules::oauth::enrich_openai_auth_json_with_account_check(
+                &access_token,
+                account.organization_id.as_deref(),
+                account.chatgpt_account_id.as_deref(),
+                &mut account.openai_auth_json,
+            )
+            .await;
+        }
+    }
+
+    if refreshed {
         storage::save_account(&app, &account).await?;
     }
 

--- a/src-tauri/src/platforms/openai/modules/account.rs
+++ b/src-tauri/src/platforms/openai/modules/account.rs
@@ -111,8 +111,8 @@ pub async fn refresh_quota_and_backfill(account: &mut Account) -> Result<QuotaDa
     Ok(quota)
 }
 
-fn missing_subscription_expiry(account: &Account) -> bool {
-    account
+pub(crate) fn missing_subscription_expiry(account: &Account) -> bool {
+    let expiry_str = account
         .openai_auth_json
         .as_deref()
         .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
@@ -121,10 +121,21 @@ fn missing_subscription_expiry(account: &Account) -> bool {
                 .get("chatgpt_subscription_active_until")
                 .and_then(serde_json::Value::as_str)
                 .map(str::trim)
-                .map(|value| !value.is_empty())
-        })
-        .map(|has_value| !has_value)
-        .unwrap_or(true)
+                .filter(|v| !v.is_empty())
+                .map(ToOwned::to_owned)
+        });
+
+    match expiry_str {
+        // 无订阅到期数据，需要补充
+        None => true,
+        Some(expiry) => {
+            // JWT id_token 中的订阅到期时间是 token 签发时的快照。
+            // 如果存储的到期日已过，可能已经自动续费，需要重新通过 API 获取。
+            chrono::DateTime::parse_from_rfc3339(&expiry)
+                .map(|dt| dt < chrono::Utc::now())
+                .unwrap_or(false)
+        }
+    }
 }
 
 pub async fn refresh_token_if_needed(


### PR DESCRIPTION
## 变更概述

修复 OpenAI 账号管理中订阅到期时间偶发显示"已过期"的问题。实际情况是 JWT 中的订阅日期滞后于实际续费日期，但判断逻辑仅检查字段是否存在，未比对实际时间。

## 变更原因

JWT `id_token` 中的 `chatgpt_subscription_active_until` 是 token 签发时的快照，不会随月度续费自动更新。当 token 有效期跨越账单周期时，JWT 中的日期落后于实际到期日。`missing_subscription_expiry` 原逻辑仅检查字段是否为空，过期日期不会被识别为过时数据，导致 `accounts/check` API 不会被调用来获取真实状态。

## 具体改动

- `missing_subscription_expiry`：改用 `chrono::DateTime::parse_from_rfc3339` 实际比对到期时间，过期则标记为缺失
- `openai_fetch_quota`：改用 `refresh_quota_and_backfill`，配额刷新时同步更新订阅信息
- `openai_refresh_account_token`：Token 刷新后增加 `missing_subscription_expiry` 判断，过期时调用 `accounts/check` API

## 影响范围

- `src-tauri/src/platforms/openai/modules/account.rs`
- `src-tauri/src/platforms/openai/commands.rs`

## 验证情况

已完成以下验证：

- `cargo check` 编译通过
- 实际调用 OpenAI `/accounts/check` API 验证，确认过期账号的订阅日期已更新为正确值
- 定时配额刷新（默认 30 分钟间隔）也会自动纠正过期的订阅日期